### PR TITLE
Automatically insert version into spec files

### DIFF
--- a/install-spotify.sh
+++ b/install-spotify.sh
@@ -21,8 +21,10 @@ RPM_SPEC_DIR="/usr/src/packages/SPECS"
 
 # Name of file residing within official Spotify repository above
 RPM_NAME="spotify-client"
-VERSION="0.8.8.323.gd143501.250-1"
-BASENAME="${RPM_NAME}_$VERSION"
+RPM_RELEASE="2"
+DEB_RELEASE="1"
+VERSION="0.8.8.323.gd143501.250"
+BASENAME="${RPM_NAME}_${VERSION}-${DEB_RELEASE}"
 
 ISSUE_TRACKER_URL="https://github.com/aspiers/opensuse-spotify-installer/issues"
 
@@ -213,9 +215,12 @@ build_rpm () {
     echo "About to build $RPM_NAME rpm; please be patient ..."
     echo
     sleep 3
+    safe_run sed -e "s/@SPOTIFY_VERSION@/${VERSION}/" \
+                 -e "s/@SPOTIFY_RELEASE@/${RPM_RELEASE}/" \
+                 "${RPM_NAME}.spec" | sudo sh -c "cat > $RPM_SPEC_DIR/${RPM_NAME}.spec"
     safe_run rpmbuild -ba "$RPM_SPEC_DIR/${RPM_NAME}.spec"
 
-    rpm="$RPM_DIR/${RPM_NAME}-${VERSION}.$rpmarch.rpm"
+    rpm="$RPM_DIR/${RPM_NAME}-${VERSION}-${RPM_RELEASE}.$rpmarch.rpm"
 
     if ! [ -e "$rpm" ]; then
         fatal "

--- a/install-spotify.sh
+++ b/install-spotify.sh
@@ -23,7 +23,7 @@ RPM_SPEC_DIR="/usr/src/packages/SPECS"
 RPM_NAME="spotify-client"
 RPM_RELEASE="1"
 DEB_RELEASE="1"
-VERSION="0.9.11.27.g2b1a638.81"
+VERSION="0.9.17.1.g9b85d43.7"
 BASENAME="${RPM_NAME}_${VERSION}-${DEB_RELEASE}"
 
 ISSUE_TRACKER_URL="https://github.com/aspiers/opensuse-spotify-installer/issues"

--- a/install-spotify.sh
+++ b/install-spotify.sh
@@ -21,9 +21,9 @@ RPM_SPEC_DIR="/usr/src/packages/SPECS"
 
 # Name of file residing within official Spotify repository above
 RPM_NAME="spotify-client"
-RPM_RELEASE="2"
+RPM_RELEASE="1"
 DEB_RELEASE="1"
-VERSION="0.8.8.323.gd143501.250"
+VERSION="0.9.11.27.g2b1a638.81"
 BASENAME="${RPM_NAME}_${VERSION}-${DEB_RELEASE}"
 
 ISSUE_TRACKER_URL="https://github.com/aspiers/opensuse-spotify-installer/issues"

--- a/spotify-client.spec
+++ b/spotify-client.spec
@@ -13,8 +13,8 @@
 # published by the Open Source Initiative.
 
 Name:           spotify-client
-Version:        0.8.8.323.gd143501.250
-Release:        1
+Version:        @SPOTIFY_VERSION@
+Release:        @SPOTIFY_RELEASE@
 License:        Commercial
 Summary:        Desktop client for Spotify streaming music service
 Url:            http://www.spotify.com/download/previews/

--- a/spotify-client.spec
+++ b/spotify-client.spec
@@ -66,9 +66,9 @@ It includes the following features:
 # unpack deb
 ar -x %{SOURCE0}
 # unpack data
-tar -xzf data.tar.gz
+tar -xJf data.tar.xz
 # remove used files
-rm {control,data}.tar.gz debian-binary
+rm control.tar.gz data.tar.xz debian-binary
 
 %define _use_internal_dependency_generator 0
 %define __find_requires %_builddir/%{name}-%{version}/find-requires.sh

--- a/spotify-installer.spec
+++ b/spotify-installer.spec
@@ -5,8 +5,8 @@
 #
 
 Name:           spotify-installer
-Version:        0.8.8.323.gd143501.250
-Release:        2
+Version:        @SPOTIFY_VERSION@
+Release:        @SPOTIFY_RELEASE@
 License:        MIT
 Summary:        Installer for Spotify desktop client
 Url:            https://github.com/aspiers/opensuse-spotify-installer/


### PR DESCRIPTION
Use placeholders in the spec files and have the install-spotify.sh script inject the version and release number into them. This way, only one file needs to be updated on version bumps.